### PR TITLE
Add imports for VGG-19 and InceptionV3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@ __pycache__/
 Flickr8k_Data_Set/
 Flickr8k_image_data/
 Flickr8k_text_data/
+Flickr10_image_data/
+Flickr10_text_data/
 model_checkpoints/
 unseen_images/
-static/
+static/uploaded_images/
 *.txt
 *.pkl
 *.png

--- a/image_caption_controller.py
+++ b/image_caption_controller.py
@@ -4,7 +4,7 @@ from flask import Flask, render_template, request, redirect, url_for, send_from_
 from werkzeug.utils import secure_filename
 
 
-UPLOAD_FOLDER = os.path.join('static')
+UPLOAD_FOLDER = os.path.join('static', 'uploaded_images')
 ALLOWED_EXTENSIONS = set(['png', 'jpg', 'jpeg'])
 
 app = Flask(__name__)
@@ -41,4 +41,4 @@ def get_caption(filename):
     full_filename = os.path.join(app.config['UPLOAD_FOLDER'], filename)
     model, tokenizer, max_length = imgcptgen.testing_params()
     caption = imgcptgen.test(model, tokenizer, max_length, full_filename)
-    return render_template("caption.html", captioned_image = filename, caption = caption)
+    return render_template("caption.html", captioned_image = 'uploaded_images/' + filename, caption = caption)

--- a/static/css/caption.css
+++ b/static/css/caption.css
@@ -1,0 +1,9 @@
+.caption-img {
+  width: 20em;
+  height: 20em;
+}
+
+.caption-txt {
+  font-style: italic;
+  font-family: cursive;
+}

--- a/templates/caption.html
+++ b/templates/caption.html
@@ -1,9 +1,10 @@
 <html>
   <head>
       <title>Generated caption</title>
+      <link rel="stylesheet" href="{{ url_for('static', filename='css/caption.css') }}">
   </head>
   <body>
-      <img src="{{ url_for('static', filename=captioned_image) }}" alt="Captioned Image">
-      <p>{{ caption }}</p>
+      <img src="{{ url_for('static', filename=captioned_image) }}" alt="Captioned Image" class="caption-img">
+      <p class="caption-txt">{{ caption }}</p>
   </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>Image Caption Generator</title>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/index.css') }}">
 <h2>Image Caption Generator<h2>
 <h3>Upload new PNG/JPG/JPEG</h3>
 <form method=post enctype=multipart/form-data>


### PR DESCRIPTION
This PR adds imports for VGG19 and InceptionV3 that were used to experiment with improving the captioning performance. VGG19 didn't make a difference difference, but InceptionV3 showed improved performance.

The following small sample files were used to debug the model. Specifically to fit the model on a small set of `<image, caption>` pairs to make sure the the CNN + LSTM caption pipeline was working correctly:

```
Flickr10_image_data/
Flickr10_text_data/
```

Additionally there are some cosmetic changes to the web API in the form of `.css` files and image `url` changes. 